### PR TITLE
Added public method psPathFilter to include a grep with FCPATH in psCmd and psInfoCmd

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -22,6 +22,15 @@ class Controller extends CI_Controller
     public $debug = true;
 
     /**
+     * Filter path when search PID
+     *  true: check the path
+     *  false: ignore path (as default in 1.0.0 and 1.0.1)
+     *
+     * @var boolean
+     */
+    public $psPathFilter = false;
+
+    /**
      * Log file path
      *
      * @var string
@@ -347,10 +356,15 @@ class Controller extends CI_Controller
         // Find out the process by name
         $psCmd = "ps aux | grep \"{$search}\" | grep -v grep";
         $psInfoCmd = "ps aux | egrep \"PID|{$search}\" | grep -v grep";
+
+        if ($this->psPathFilter) {
+            $psCmd .= " | grep ".FCPATH;
+            $psInfoCmd .= " | grep ".FCPATH;
+        }
+
         $exist = (shell_exec($psCmd)) ? true : false;
 
         if ($exist) {
-            
             $psInfo = shell_exec($psInfoCmd);
             die("Skip: Same process `{$action}` is running: {$route}.\n------\n{$psInfo}");
         }


### PR DESCRIPTION
Hi, I have multiple instances of same web application on the server, in differents vhosts, when a "worker" of an instance start and there is a the same "worker" active in another instance, the last called don't start, because ps ${search} find the PID of the first instance.

To prevent that, I wrote a small patch, I created a public method to set the behaviour, becase in some situation multiple instances use same 'resources' and only one worker must run.

I used FCPATH to discriminate the vhost where worker is running.